### PR TITLE
Support pprof file lz4-compressed

### DIFF
--- a/dotnet-pprof/Program.cs
+++ b/dotnet-pprof/Program.cs
@@ -126,9 +126,7 @@ namespace dd_pprof
 
             try
             {
-                using var s = File.OpenRead(parameters.filename);
-                var profile = Profile.Parser.ParseFrom(s);
-                DumpPProfEx(profile, parameters.showAll);
+                DumpPProfEx(parameters.filename, parameters.showAll);
             }
             catch (Exception x)
             {
@@ -275,15 +273,15 @@ namespace dd_pprof
             Console.WriteLine();
         }
 
-        static void DumpPProfEx(Profile profile, bool showAll)
+        static void DumpPProfEx(string filename, bool showAll)
         {
-            var wrapper = new PProfFile();
-            if (!wrapper.Load(profile))
+            PProfFile wrapper = new();
+            if (!wrapper.Load(filename))
             {
                 return;
             }
 
-            TimeSpan ts = new TimeSpan(0, 0, 0, 0, (int)(profile.DurationNanos / 1000000));
+            TimeSpan ts = new TimeSpan(0, 0, 0, 0, (int)(wrapper.DurationNS / 1000000));
             Console.WriteLine($"Duration: {ts.TotalSeconds} s");
             Console.WriteLine();
 

--- a/dotnet-pprof/dotnet-pprof.csproj
+++ b/dotnet-pprof/dotnet-pprof.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.20.1" />
+    <PackageReference Include="K4os.Compression.LZ4.Streams" Version="1.3.6" />
   </ItemGroup>
 
 </Project>

--- a/win-pprof/MainWindow.xaml.cs
+++ b/win-pprof/MainWindow.xaml.cs
@@ -162,14 +162,13 @@ namespace win_pprof
             }
         }
 
+
         public void OpenFile(string filename)
         {
             try
             {
-                using var s = File.OpenRead(filename);
-                var profile = Profile.Parser.ParseFrom(s);
                 _profile = new PProfFile();
-                if (!_profile.Load(profile))
+                if (!_profile.Load(filename))
                 {
                     MessageBox.Show($"Error while loading {filename}");
                     return;

--- a/win-pprof/win-pprof.csproj
+++ b/win-pprof/win-pprof.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.21.0" />
+    <PackageReference Include="K4os.Compression.LZ4.Streams" Version="1.3.6" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Pprof files can now be compressed using LZ4.

This PR adds support for LZ4-compressed pprof files.