### PR TITLE
Display filepath and line number

### DIFF
--- a/PProfFile.cs
+++ b/PProfFile.cs
@@ -168,7 +168,7 @@ public class PProfFile
         _functions = new List<Function>(_profile.Function.Count);
         foreach (var function in _profile.Function)
         {
-            _functions.Add(new Function(function.Id, GetString(function.Name)));
+            _functions.Add(new Function(function.Id, GetString(function.Name), GetString(function.Filename), function.StartLine));
         }
 
         Functions = _functions;
@@ -194,10 +194,13 @@ public class PProfFile
             var frames = new List<Frame>(framesCount);
             for (int i = 0; i < framesCount; i++)
             {
+                var function = GetFunction((int)entry.Line[i].FunctionId);
                 frames.Add(
                     new Frame(
                         entry.Line[i].FunctionId,
-                        GetFunctionName((int)entry.Line[i].FunctionId),
+                        function.Name,
+                        function.Filename,
+                        function.StartLine,
                         i != (framesCount - 1)  // the last frame is not inlined
                         )
                     );
@@ -295,15 +298,19 @@ public class Mapping
 
 public class Frame
 {
-    public Frame(ulong id, string name, bool isInlined)
+    public Frame(ulong id, string name, string filePath, long line, bool isInlined)
     {
         Id = id;
         Name = name;
         IsInlined = isInlined;
+        FilePath = filePath;
+        Line = line;
     }
 
     public ulong Id { get; }
     public string Name { get; }
+    public string FilePath { get; }
+    public long Line { get; }
     public bool IsInlined { get; }
 }
 
@@ -329,14 +336,18 @@ public class Location
 
 public class Function
 {
-    public Function(ulong id, string name)
+    public Function(ulong id, string name, string filename, long startLine)
     {
         Id = id;
         Name = name;
+        Filename = filename;
+        StartLine = startLine;
     }
 
     public ulong Id { get; }
     public string Name { get; }
+    public string Filename { get; }
+    public long StartLine { get; }
 }
 
 

--- a/win-pprof/MainWindow.xaml
+++ b/win-pprof/MainWindow.xaml
@@ -107,6 +107,10 @@
                                                     DisplayMemberBinding="{Binding Path=Name}"
                                                     util:GridViewSort.PropertyName="Name"
                                                     />
+                                    <GridViewColumn Header="Filename" Width="900"
+                                                    DisplayMemberBinding="{Binding Path=Filename}"
+                                                    util:GridViewSort.PropertyName="Filename"
+                                                    />
                                 </GridView.Columns>
                             </GridView>
                         </ListView.View>
@@ -145,6 +149,14 @@
                                     <GridViewColumn Header="Name" Width="1000"
                                                     DisplayMemberBinding="{Binding Path=Name}"
                                                     util:GridViewSort.PropertyName="Name"
+                                                    />
+                                    <GridViewColumn Header="Filename" Width="1000"
+                                                    DisplayMemberBinding="{Binding Path=Filename}"
+                                                    util:GridViewSort.PropertyName="Filename"
+                                                    />
+                                    <GridViewColumn Header="StartLine" Width="50"
+                                                    DisplayMemberBinding="{Binding Path=StartLine}"
+                                                    util:GridViewSort.PropertyName="StartLine"
                                                     />
                                 </GridView.Columns>
                             </GridView>

--- a/win-pprof/MainWindow.xaml.cs
+++ b/win-pprof/MainWindow.xaml.cs
@@ -233,7 +233,5 @@ namespace win_pprof
 
 #region Locations
 #endregion
-
-
     }
 }

--- a/win-pprof/SamplesControl.xaml.cs
+++ b/win-pprof/SamplesControl.xaml.cs
@@ -13,6 +13,8 @@ namespace win_pprof
         public ulong Address { get; set; }
         public string Text { get; set; }
         public string IsInlined { get; set; }
+        public string Filename { get; set; }
+        public long StartLine { get; set; }
     }
 
     public partial class SamplesControl : UserControl
@@ -56,7 +58,9 @@ namespace win_pprof
                     {
                         Address = location.Address,
                         IsInlined = (frame.IsInlined) ? "-" : string.Empty,
-                        Text = frame.Name
+                        Text = frame.Name,
+                        Filename = frame.FilePath,
+                        StartLine = frame.Line
                     };
 
                     lvFrames.Items.Add(frameInfo);


### PR DESCRIPTION
Extract filepath and line number associated to frames.
![image](https://github.com/chrisnas/Win-pprof/assets/17292193/fa7d45c3-940e-4c64-b3a2-5a0200b27c3e)

